### PR TITLE
Sprint 3 Chat Feedback

### DIFF
--- a/app/src/main/java/edu/uw/tcss450/chatapp_group1/MainActivity.java
+++ b/app/src/main/java/edu/uw/tcss450/chatapp_group1/MainActivity.java
@@ -145,7 +145,7 @@ public class MainActivity extends AppCompatActivity {
                 //When the user navigates to the chats page, reset the new message count.
                 //This will need some extra logic for your project as it should have
                 //multiple chat rooms.
-                mNewMessageModel.reset();
+                mNewMessageModel.reset(arguments.getInt("chatid"));
             }
             if (destination.getId() == R.id.navigation_contact){
                 mNewRequestModel.reset();
@@ -393,10 +393,11 @@ public class MainActivity extends AppCompatActivity {
             NavDestination nd = nc.getCurrentDestination();
             if (intent.hasExtra("chatMessage")) {
                 ChatMessage cm = (ChatMessage) intent.getSerializableExtra("chatMessage");
+                int chatId = intent.getIntExtra("chatid", -1);
                 //If the user is not on the chat screen, update the
                 // NewMessageCountView Model
                 if (nd.getId() != R.id.chatRoomFragment) {
-                    mNewMessageModel.increment();
+                    mNewMessageModel.increment(chatId);
                 }
                 //Inform the view model holding chatroom messages of the new
                 //message.

--- a/app/src/main/java/edu/uw/tcss450/chatapp_group1/model/NewMessageCountViewModel.java
+++ b/app/src/main/java/edu/uw/tcss450/chatapp_group1/model/NewMessageCountViewModel.java
@@ -13,7 +13,14 @@ import java.util.Map;
  * View model to store data about new message notification counts.
  */
 public class NewMessageCountViewModel extends ViewModel {
+    /**
+     * Map to store {chat room id, new message count}.
+     */
     private MutableLiveData<Map<Integer, Integer>> mNewMessageCount;
+
+    /**
+     * Integer to store count of total new messages.
+     */
     private MutableLiveData<Integer> mTotalMessageCount;
 
     /**

--- a/app/src/main/java/edu/uw/tcss450/chatapp_group1/model/NewMessageCountViewModel.java
+++ b/app/src/main/java/edu/uw/tcss450/chatapp_group1/model/NewMessageCountViewModel.java
@@ -6,24 +6,69 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModel;
 
-public class NewMessageCountViewModel extends ViewModel {
-    private MutableLiveData<Integer> mNewMessageCount;
+import java.util.HashMap;
+import java.util.Map;
 
+/**
+ * View model to store data about new message notification counts.
+ */
+public class NewMessageCountViewModel extends ViewModel {
+    private MutableLiveData<Map<Integer, Integer>> mNewMessageCount;
+    private MutableLiveData<Integer> mTotalMessageCount;
+
+    /**
+     * Constructor.
+     */
     public NewMessageCountViewModel() {
         mNewMessageCount = new MutableLiveData<>();
-        mNewMessageCount.setValue(0);
+        mNewMessageCount.setValue(new HashMap<>());
+        mTotalMessageCount = new MutableLiveData<>();
+        mTotalMessageCount.setValue(0);
     }
 
+    /**
+     * Add an observer to this instance
+     * @param owner the owner
+     * @param observer the observer
+     */
     public void addMessageCountObserver(@NonNull LifecycleOwner owner,
                                         @NonNull Observer<? super Integer> observer) {
-        mNewMessageCount.observe(owner, observer);
+        mTotalMessageCount.observe(owner, observer);
     }
 
-    public void increment() {
-        mNewMessageCount.setValue(mNewMessageCount.getValue() + 1);
+    /**
+     * Increment the total new message number.
+     * @param chatId the id of the specified chat room
+     */
+    public void increment(int chatId) {
+        // if message count key exists for that chat room, just increment it
+        if (mNewMessageCount.getValue().containsKey(chatId)) {
+            int currentMessageCount = mNewMessageCount.getValue().get(chatId);
+            int newMessageCount = currentMessageCount + 1;
+            mNewMessageCount.getValue().put(chatId, newMessageCount);
+        } else {
+            // message count key doesn't exist in map, create it
+            mNewMessageCount.getValue().put(chatId, 1);
+        }
+        // increment total message badge count
+        mTotalMessageCount.setValue(mTotalMessageCount.getValue() + 1);
     }
 
-    public void reset() {
-        mNewMessageCount.setValue(0);
+    /**
+     * Change the total new message number to its new value after entering a chat room.
+     * @param chatId the id of the specified chat room
+     */
+    public void reset(int chatId) {
+        if (mNewMessageCount.getValue().containsKey(chatId)) {
+            // get current message count for that chat room
+            int currentMessageCount = mNewMessageCount.getValue().get(chatId);
+            System.out.println("Current message count for chatid: " + chatId + " is " + currentMessageCount);
+            if (currentMessageCount > 0) {
+                // reset that message count to zero, and subtract that count from the total message badge count
+                mNewMessageCount.getValue().put(chatId, 0);
+                mTotalMessageCount.setValue(mTotalMessageCount.getValue() - currentMessageCount);
+                System.out.println("New total message count is: " + mTotalMessageCount.getValue());
+            }
+        }
     }
 }


### PR DESCRIPTION
# Description

Implements Charles' sprint 3 chat feedback. New message notification count/badge now functions properly for multiple chat rooms. Entering a chat room should now clear message notifications for that room only. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested between two devices sending messages to each other in multiple chat rooms.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas